### PR TITLE
add spark session wrapper to use along in the examples.

### DIFF
--- a/src/main/scala/com/sparkbyexamples/spark/SparkSessionWrapper.scala
+++ b/src/main/scala/com/sparkbyexamples/spark/SparkSessionWrapper.scala
@@ -1,0 +1,14 @@
+package com.sparkbyexamples.spark
+
+import org.apache.spark.sql.SparkSession
+
+trait SparkSessionWrapper {
+  lazy val spark: SparkSession = {
+    SparkSession
+      .builder()
+      .master("local")
+      .appName("spark session")
+      .config("spark.sql.shuffle.partitions", "1")
+      .getOrCreate()
+  }
+}


### PR DESCRIPTION
add spark session wrapper as a best practices to use along the examples.